### PR TITLE
Introduces developer landing page and flexible docs build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@
 #
 # Deployment webhooks (repo-level, optional — omit if no deploy target):
 #   WEBHOOK_URL_DEV     - Portainer service webhook URL for dev redeploy
+#
+# Images built:
+#   scbd/clearing-house-documentation  - VitePress docs site
+#   scbd/developer.cbd.int             - Landing page
 name: CI
 on:
   push:
@@ -17,6 +21,7 @@ permissions:
   contents: read
 env:
   IMAGE_NAME: scbd/clearing-house-documentation
+  LANDING_IMAGE_NAME: scbd/developer.cbd.int
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -101,6 +106,32 @@ jobs:
             docker tag ci-build:local "$tag"
             docker push "$tag"
           done <<< "${{ steps.meta.outputs.tags }}"
+      - name: Build landing image
+        uses: docker/build-push-action@v6
+        with:
+          context: landing
+          load: true
+          tags: ci-landing:local
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Test landing image
+        run: |
+          docker run --name landing -d -p 3000:3000 ci-landing:local
+          sleep 5
+          docker exec landing wget -qO- http://localhost:3000
+      - name: Push landing image
+        if: steps.meta.outputs.push == 'true'
+        run: |
+          IMAGE="${{ env.LANDING_IMAGE_NAME }}"
+          if [[ -n "${{ steps.meta.outputs.build_tag }}" ]]; then
+            docker tag ci-landing:local "${IMAGE}:${{ steps.meta.outputs.build_tag }}"
+            docker tag ci-landing:local "${IMAGE}:latest"
+            docker push "${IMAGE}:${{ steps.meta.outputs.build_tag }}"
+            docker push "${IMAGE}:latest"
+          else
+            docker tag ci-landing:local "${IMAGE}:${{ steps.meta.outputs.branch }}"
+            docker push "${IMAGE}:${{ steps.meta.outputs.branch }}"
+          fi
       # Portainer webhooks — non-critical, a failed redeploy never blocks CI.
       - name: Deploy to Portainer (dev)
         if: steps.meta.outputs.branch == 'dev'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
       #   calver tag (YYYY.N.N) → tags=<tag> + latest,              push=true
       #   master/dev           → tags=<branch>,                     push=true
       #   other branches       → tags=build-<sha>,                  push=false
+      #
+      # The image itself is base-path-agnostic: docker-entrypoint.sh rewrites
+      # the built site to whatever $BASE_PATH the container is run with, so
+      # no branch-specific base path needs to be baked in at build time.
       - name: Resolve image tags
         id: meta
         run: |
@@ -49,24 +53,17 @@ jobs:
             echo "push=true"                    >> $GITHUB_OUTPUT
             echo "branch="                      >> $GITHUB_OUTPUT
             echo "build_tag=${TAG}"             >> $GITHUB_OUTPUT
-            echo "base_path=/clearing-house/"   >> $GITHUB_OUTPUT
           elif [[ "${REF}" =~ ^refs/heads/(master|dev)$ ]]; then
             BRANCH="${BASH_REMATCH[1]}"
             echo "tags=${IMAGE}:${BRANCH}"      >> $GITHUB_OUTPUT
             echo "push=true"                    >> $GITHUB_OUTPUT
             echo "branch=${BRANCH}"             >> $GITHUB_OUTPUT
             echo "build_tag="                   >> $GITHUB_OUTPUT
-            if [[ "${BRANCH}" == "master" ]]; then
-              echo "base_path=/clearing-house/" >> $GITHUB_OUTPUT
-            else
-              echo "base_path=/"               >> $GITHUB_OUTPUT
-            fi
           else
             echo "tags=${IMAGE}:build-${SHORT_SHA}" >> $GITHUB_OUTPUT
             echo "push=false"                        >> $GITHUB_OUTPUT
             echo "branch="                           >> $GITHUB_OUTPUT
             echo "build_tag="                        >> $GITHUB_OUTPUT
-            echo "base_path=/"                       >> $GITHUB_OUTPUT
           fi
       - name: Log in to Docker Hub
         if: steps.meta.outputs.push == 'true'
@@ -81,7 +78,6 @@ jobs:
             COMMIT=${{ github.sha }}
             BRANCH=${{ steps.meta.outputs.branch }}
             TAG=${{ steps.meta.outputs.build_tag }}
-            BASE_PATH=${{ steps.meta.outputs.base_path }}
           load: true
           tags: ci-build:local
           cache-from: type=gha
@@ -89,6 +85,7 @@ jobs:
       - name: Test image
         run: |
           docker run --name clearing-house-documentation -d -p 8000:8000 \
+            -e BASE_PATH=/clearing-house/ \
             -e VITE_API_URL=https://api.cbddev.xyz \
             -e VITE_ACCOUNTS_HOST_URL=https://accounts.cbddev.xyz \
             -e VITE_ABS_URL=https://absch.cbddev.xyz \
@@ -97,7 +94,10 @@ jobs:
             -e VITE_ORT_URL=https://ort.cbddev.xyz \
             ci-build:local
           sleep 10
-          docker exec clearing-house-documentation curl --retry 10 --retry-delay 5 -v http://localhost:8000
+          docker exec clearing-house-documentation curl --retry 10 --retry-delay 5 -v http://localhost:8000/clearing-house/
+          docker exec clearing-house-documentation sh -c \
+            "curl -sf http://localhost:8000/clearing-house/ | grep -q '/clearing-house/assets/' \
+            && echo 'base path correctly rewritten' || (echo 'base path NOT rewritten' && exit 1)"
       - name: Push image
         if: steps.meta.outputs.push == 'true'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
         run: |
           docker run --name landing -d -p 3000:3000 ci-landing:local
           sleep 5
-          docker exec landing wget -qO- http://localhost:3000
+          docker exec landing curl --retry 10 --retry-delay 5 -v http://localhost:3000
       - name: Push landing image
         if: steps.meta.outputs.push == 'true'
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use a node base image
-FROM node:20
+FROM node:24
 
 # Set build arguments and environment variables
 ARG BRANCH='master'

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,6 @@ ENV TAG=$TAG
 ARG COMMIT
 ENV COMMIT=$COMMIT
 
-ARG BASE_PATH='/'
-ENV BASE_PATH=$BASE_PATH
-
 # Set working directory
 WORKDIR /usr/src/app
 
@@ -24,17 +21,17 @@ RUN npm install --prefer-offline && \
 
 # Copy the rest of the application code
 COPY . .
+RUN chmod +x docker-entrypoint.sh
 
-# Change to the docs directory and run the VitePress build script
+# Build with a placeholder base path; the real path is substituted at
+# container startup by docker-entrypoint.sh, based on $BASE_PATH. Set only
+# for this RUN step, not as an image-level ENV, so it doesn't leak into
+# the runtime default.
 WORKDIR /usr/src/app/docs
-
-
-# Build the VitePress site
-RUN npm run build
+RUN BASE_PATH=/__BASE_PATH__/ npm run build
 
 # Set port and expose it
 ENV PORT=8000
 EXPOSE 8000
 
-# Command to start the VitePress preview
-CMD ["npm", "run", "preview"]
+ENTRYPOINT ["/usr/src/app/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+# Built with a placeholder base path ("/__BASE_PATH__/", see Dockerfile).
+# Swap it here for the real $BASE_PATH so one image works at any sub-path.
+base="${BASE_PATH:-/}"
+
+# Normalize to "/path/" form (leading + trailing slash), matching the
+# placeholder shape, so BASE_PATH can be given with or without slashes.
+case "$base" in /*) ;; *) base="/$base" ;; esac
+case "$base" in */) ;; *) base="$base/" ;; esac
+
+dist="/usr/src/app/docs/.vitepress/dist"
+# Replace the /__BASE_PATH__/ placeholder in all files in the dist directory.
+grep -rl '/__BASE_PATH__/' "$dist" | xargs -r sed -i "s#/__BASE_PATH__/#${base}#g"
+
+cd /usr/src/app/docs
+exec npm run preview

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -3,10 +3,12 @@ import { resolve } from "path";
 import routes from "../../routes/index";
 
 export default defineConfig({
-  title: "API Documentation",
+  title: "CH documentation",
   base: process.env.BASE_PATH || "/",
   appearance: false,
   themeConfig: {
+    logo: "/logo.png",
+    siteTitle: "CH documentation",
     aside: true,
     nav: [
       {

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -20,10 +20,13 @@ export default {
     // Register global components
     app.component('SchemaRow', SchemaRow)
     app.component('SchemaTable', SchemaTable)
-    // Add onMounted here if needed for further setup
-    onMounted(async () => {
-      // Import the global CSS and JS for Bootstrap
-      
+  },
+  setup() {
+    // VPNavBarTitle doesn't expose a slot for a title/tooltip attribute,
+    // so set it directly on the nav brand link.
+    onMounted(() => {
+      document.querySelector(".VPNavBarTitle .title")
+        ?.setAttribute("title", "Clearing-House Documentation");
     });
   }
 };

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -17,23 +17,6 @@ if (!import.meta.env.SSR) {
 export default {
   ...DefaultTheme,
   enhanceApp({ app }: { app: any }) {
-    // Validate mandatory environment variables at runtime
-    if (!import.meta.env.SSR) {
-      const mandatoryEnvVars = [
-        'VITE_ACCOUNTS_HOST_URL', 
-        'VITE_API_URL',
-        'VITE_ABS_URL',
-        'VITE_BCH_URL',
-        'VITE_CHM_URL',
-        'VITE_ORT_URL'
-      ];
-      mandatoryEnvVars.forEach((variable) => {
-        if (!import.meta.env[variable]) {
-          console.error(`Missing mandatory environment variable: ${variable}`);
-        }
-      });
-    }
-
     // Register global components
     app.component('SchemaRow', SchemaRow)
     app.component('SchemaTable', SchemaTable)

--- a/docs/app-config.ts
+++ b/docs/app-config.ts
@@ -1,12 +1,11 @@
-// The Playground always targets the dev sandbox (cbddev.xyz), not the
-// production domain (cbd.int), so these are hardcoded rather than read
-// from per-environment build vars.
+// The Playground always targets the production domain (cbd.int), so these
+// are hardcoded rather than read from per-environment build vars.
 export const APP_CONFIG = {
-  ACCOUNTS_HOST_URL: 'https://accounts.cbddev.xyz',
-  API_URL: 'https://api.cbddev.xyz',
-  ABS_URL: 'https://absch.cbddev.xyz',
-  BCH_URL: 'https://bch.cbddev.xyz',
-  CHM_URL: 'https://chm.cbddev.xyz',
-  ORT_URL: 'https://ort.cbddev.xyz',
+  ACCOUNTS_HOST_URL: 'https://accounts.cbd.int',
+  API_URL: 'https://api.cbd.int',
+  ABS_URL: 'https://absch.cbd.int',
+  BCH_URL: 'https://bch.cbd.int',
+  CHM_URL: 'https://chm.cbd.int',
+  ORT_URL: 'https://ort.cbd.int',
   API_EXTENSION: 'api/v2013'
 }

--- a/docs/app-config.ts
+++ b/docs/app-config.ts
@@ -1,9 +1,12 @@
+// The Playground always targets the dev sandbox (cbddev.xyz), not the
+// production domain (cbd.int), so these are hardcoded rather than read
+// from per-environment build vars.
 export const APP_CONFIG = {
-  ACCOUNTS_HOST_URL: import.meta.env.VITE_ACCOUNTS_HOST_URL,
-  API_URL: import.meta.env.VITE_API_URL,
-  ABS_URL: import.meta.env.VITE_ABS_URL,
-  BCH_URL: import.meta.env.VITE_BCH_URL,
-  CHM_URL: import.meta.env.VITE_CHM_URL,
-  ORT_URL: import.meta.env.VITE_ORT_URL,
+  ACCOUNTS_HOST_URL: 'https://accounts.cbddev.xyz',
+  API_URL: 'https://api.cbddev.xyz',
+  ABS_URL: 'https://absch.cbddev.xyz',
+  BCH_URL: 'https://bch.cbddev.xyz',
+  CHM_URL: 'https://chm.cbddev.xyz',
+  ORT_URL: 'https://ort.cbddev.xyz',
   API_EXTENSION: 'api/v2013'
 }

--- a/landing/Dockerfile
+++ b/landing/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:24-alpine
 
 WORKDIR /app
 

--- a/landing/Dockerfile
+++ b/landing/Dockerfile
@@ -2,7 +2,8 @@ FROM node:20-alpine
 
 WORKDIR /app
 
-RUN npm init -y && npm install express && npm pkg set type=module
+COPY package.json ./
+RUN apk add --no-cache curl && npm install --omit=dev
 
 COPY . .
 

--- a/landing/Dockerfile
+++ b/landing/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+RUN npm init -y && npm install express && npm pkg set type=module
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/landing/index.html
+++ b/landing/index.html
@@ -134,6 +134,27 @@ section.band{padding:54px 0;}
 .sup .sdesc{font-size:13.5px;color:var(--muted);line-height:1.55;flex:1;}
 .sup .slink{font-size:13.5px;font-weight:700;color:var(--accent-ink);font-family:var(--mono);}
 
+/* status */
+.status-overall{display:flex;align-items:center;gap:10px;font-weight:700;font-size:15px;
+  color:var(--ink);margin-bottom:22px;}
+.svc-list{border:1px solid var(--line);border-radius:13px;background:#fff;overflow:hidden;}
+.svc{display:flex;align-items:center;gap:14px;padding:16px 20px;border-bottom:1px solid var(--line);}
+.svc:last-child{border-bottom:none;}
+.svc-name{font-weight:700;color:var(--ink);min-width:170px;}
+.svc-url{font-family:var(--mono);font-size:13px;color:var(--muted);flex:1;}
+.dot{width:10px;height:10px;border-radius:50%;background:var(--muted);flex-shrink:0;}
+.dot.up{background:var(--green-600);}
+.dot.down{background:#b3261e;}
+.svc-badge{font-size:13px;font-weight:700;color:var(--muted);white-space:nowrap;}
+.svc-badge.up{color:var(--green-700);}
+.svc-badge.down{color:#b3261e;}
+.status-note{margin-top:18px;font-size:13px;color:var(--muted);line-height:1.6;}
+@media (max-width:560px){
+  .svc{flex-wrap:wrap;}
+  .svc-name{min-width:0;width:100%;}
+  .svc-url{width:100%;}
+}
+
 /* footer */
 .foot{border-top:1px solid var(--line);padding:26px 0 30px;margin-top:auto;}
 .foot .frow{display:flex;align-items:center;justify-content:space-between;gap:20px;}
@@ -164,19 +185,15 @@ section.band{padding:54px 0;}
 <div class="topbar">
   <div class="wrap top-inner">
     <a class="blogo" href="/">
-      <svg width="30" height="33" viewBox="0 0 60 66" fill="none" aria-hidden="true">
-        <path d="M30 4C18 14 14 26 18 40c2 7 7 13 12 18 5-5 10-11 12-18 4-14 0-26-12-36Z" fill="#0f5c34"></path>
-        <path d="M30 8c-7 8-9 18-6 28 1.5 5 4 9 6 12 2-3 4.5-7 6-12 3-10 1-20-6-28Z" fill="#7cc294"></path>
-        <path d="M30 12v50" stroke="#fff" stroke-width="1.6"></path>
-      </svg>
-      <span class="bt">CBD <span>Developers</span></span>
+      <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAYMAAACXBAMAAAAFeioYAAAAMFBMVEVHcEwAmkcAmkcAm0gAmkYAmEQAmkYAmkYAmkYAm0cAmkYAmUUAmkYAmkYAm0gAmERRi+2MAAAADnRSTlMAwECA2YCZEPBXIGkwsA5/H3AAAA3bSURBVHja1JttbFPXGYCPP8iNP8LijTJtQ7bnrq1WuiSbp2msEwqlW4aq2nRS+rEKJdCiapvk3HUpokJj6doVwZATlY3yZ8HtEOpUCTK2/ekPcLNuQpoEWTtpUidBTKxgSnmlTCkNY+jsfc+5tq/je67tQMO99wck5xzfvM+95/0+ZmzJV2SCufzS+Ga3I4Tcj9DhfoTj7kcYcD2CNup6hDbueoSz7kdIux4B95HbEU5xt6tziHO3G9VT/Ea3uxF2cN7nboRQmi/kXY2wCw3qfuZihMktaE/ncy5EmLyrv39rZBUX1wJK7zIE7WCam66Fx5jbELxDZgD+3THmNoRwzCT//Oq35KibEDTxDjZs738ykbinOuwmhCO0d+J1wy5CCI9yvs1i3EUIpzn/NHM1Ar6Ej5i7EYb5QtzlCEMYDrkbwct53OUIfn6duRxhgHe6HWF0IedyhJDCoroIwc/3uB3hLB90O8IQzzkfwZuzm03PM+cjDEzZBUhKr+AohBFbg/RfG4QJpyBcs5ns4L02Ti/uFIQbtjZVaZBYjDsngrDR50+pN0uQ33AOgvpB435XbpYVNpq+7Ah71JOH1a/oDbvPLTfCVbtJ5dR55zjnAW5jWdQIIb6gOwihTx1fKJ3zKX7NQTmNjWmJzSmV2c4KLDfCvI00KoRgjM/rzkGYG1IrtAIhOGS3+24DwjDnz7SEEECCG7qTEMKcz+ebR3idGlULE8xJCGhd+NVcQ4TJxG/6H41ERkWX4UfMWQghlOnqmC3CXf+saVQ5ioAQ2Dsk1+onE4m8NULovEWjylkI2uNV+SKRO57I1SI8N1qdfiGy/V6nJfiEwLQ/1Tzm+R+aEQJEMH9H/xOJhDNrFANyr/w1VgPxHb2CIFptD+Wau9vr+db+etDcvbtJBMbWPlJujNP1qwoCug3rNk/9pX0d4N2W/roPLtxCBKNmkUj8WVifzxsIWprzvU3e6wjg1ayue0n6TwJBXG/irhK9HUTw8+bDoRQhfOgIBBEEXZcIQ83HpAGATevhSisI3uS3PiEE5sXtM0EIAW6X1dVebXAZHyvoLSDcSotUJw7n/yOEnS0kBh4YYUEA3IG/T9Iph2cTuhftsBc9ZjiBo+HkOp20LR9M5Jh3LVxO6NIi3ZkkBUrcyybL9kk7kMxXli4RAQMnzCxjc+dbSAxWQidjhNCGKvEvxrrgyymYYu1I5odpFowCvEign83gC1hJehMXuvAOQBEZYOY1KBkCH8KhPC7tzMClJSPgDppisQXO97GWETIoXYEQMqTdHfAB241TwyR0D8r1IMpnQghm8SckgSv4w2BZqwD2lZcuFQEz0muM/J0yrJ7UrRASuDtAGtcugO/BDAvhg+xC2cahkIKLKBe8BGBCoHdGxChtiu6Al5+GZmnpC7h0yQge3EKIMKf8ZHqzFYJ4hkU9g8+7C34RQIQwCrMeic5B3IM0HpjVo2Ayqn64EM4CIUy0G3dYCfvwJrj0Ct5o6Qh0uh8RlKXtIFch+FDQY/jYu1BuRGDZAoqfY9EiIyIP9CKRCYE+lsF58djlHeilpQB/7RNLl4qACr0nZmOPQjYIF8XPXagWhHAOWAp3dLSAL2RGiLkIoQcHxNIqQg+LQmXpkhH8/HrMpuDlt0GYrkE4CfeQw4uWIpEWENbfAoQQn4/Z+LXuphHOwAn6L0o6urwILM3TNl2eWNMI7fAeiXs7EAY4+QZVfMCtEQ4kc4sROuBhHEF1TiaTX1tehOOIoAydPQqEKBn7WoQQFNEKkTrLMGQZETDOXmBqe2WBMEIBdx1CGITXRYRgC28h0zyCurPcZhOl0qHDxQjtKLqG3tSHEYUZgWVFIoR+wYuxrAXC4M0Z1cNct9nuygr8sMV3eTwi2C4J13ZGuDYD4Ryg5yKZAihxFeFSGaEXV+hmhDNl19YUws/VQZDG+cdqe5SuQ8BgZ1sGfSzGBq+kRIBhIJxELobCvH8Eo74qQvGVnAwwZtZSJGRCWAmX78awqUkEv/LMFFnVXsXMDs5P1SHI8O4C0yj0hHwV4QxFcfgvXr0VuUhDeiph3mwNQket/W1whfh/bEy/IrzQ0vwjiwMMFGST4o5LmSoI7eJfErWUr8oVNRC0lIiszQhhegh9zSJoo3aOYbP1xCHOOy0QfOLZYaiaglIPY29H8hKhQ+aY3wRYgySRQSnXDgOBfiigrkQ+V0Fgb+Mz0KtLG5kktTKoEL5IVQ2rYyRvfvX+nKxwWZbEEopaJmao9UMtJM87KUlWWSsrBO0PnJo8DjpSFeAL+WYjOSqUbaEvlFx11qmwoWaOov59i7lcORd3FkKbUX20QdhV22C4EWcOO5s3pGo8laU8OlpTuv+xzpyGQI2qL+TUCM+ZOySrv6+rUp7beVGjan57vWWTUoZJf+e2v7KoFeCwQ57lJs9cJNLffyJfKyWG1Qvbmkk8b+/12xp1fdj8vS/U9vkJ5nwE9vzTNRAPVTUW08/HmBsQcMuv7d8SiZQZfqkbUoa44mskDj7w/OzaR4jhAUPKs6rSdj3C75LJ+4XKH1hXGbszWfdB02w5PEzKFP1AMrkuL24UtxHQZztbjjnIkw1KKdOqMy/1CF0Ua69hlUSfiTyn7oOm2UXVGyrTFCdk3mlXQO9hWsNOKTWqZBi0gqu+g6FAKMVvDkEmGo0QmmgRkS8YJCmPKzMiBQLsuUkEzJNuCYKsXqCUQ8q6sBXChYToykzeZ4dgmq1DOHE3wBQmCzkb0bzU5mqmUXeY87Fu/gN1n8oKYRpz+dmaMVXSVbOZqwhxdpIKfw2vphDQmO7r5o+qzwRbIwQo0xc252Dk37qB8LfIZ+ixBp8uvRvcmqdZDdNsOor2/NbVY7UIu+EDskje5LdZMIkrd/2DVgSSY0c7WfCPlBSiRfJ9A2aTuWSSjFfO7jXMdfPH1UfnrRG89BZot/8Ed/V+iUB5/2UmqwK/hjjNUt+tpLMwZv4FvQbBj88XdYGaKaJFlBUrPLAmO03lhRmhC7LLFQUd759XI6zgfIin1Ym1NYJPlOELsppRygmEcdl6k7UZibBe1jp20n8TNQgeiaDh26TagFjRiaOrYNonP1RBoO5XtGS3leTZGL01hEO4DwhBA9hA0hFCCjZkUYwQFNHkpARCCl5OwQjObozijAWCLOZdRNV4MSPqZwDTu2GjbPf2eFZBMZKnZdmCHcIbnPOWWiRdUFglq6cF3FAF/F2WgaCo70Q6D0z5YDasEwJujmEcSkFupwIhA/l2UanMt4lCbPGteBfkQnClalTxY0FR5LHNhFr6Lo/wC5uk5Q+gcW0vI8yiOpCxigcNTdHwL9OQ6GpaI4zDBLUcRS15RrwQUTt+8NUqggdGAg0sE6U6H9uoe9wKYaNE8FULwCSCrNfHGdkr8Y5QWZPCfw0rEHbDIFKIir7RJqUmMNNNrq0NPvQ1MMHdiNBrk3HnLL1zX5MI8joKCgQ/9OJeMvcYkQreN3tnfNMCzbZibHeGJF3XPkHv7M0YFskCwW+BcBRUCG1wkRrspgYdGWeqc1YQNJhth8EGRTKbRlW4XtMRAZ9MSYXggbGwoQtlhEAWigoE3OWC14RAhrqom2KkVPFYo0NoozZfz2irj/8IgYyMAiEEfT+jCMqEMA7FvygQNLgiXmi1xyjKzbhxqggZGIdcwwKTjaL0WiJkUAxrBOHaRioIwUQceZ/xKRDolNylmh4jXj/N4lgVYRyijc7JnFUjaBZ+WyCcUyKw01D2GmE55MUgYzHCSvSNAgF3zUW5uFK1D7LXzH6BHYOGx+j8aoQOiyMyXbLDI/5uSHSgBELZCVDTwPAahquggGoxwjiuFAjjIDq9JcMv4IqDL+HtCwYCnbTyy9jLPmmYU++x/ZYIXxKnLQoi3DtT8c7iVFgAHrivnPJAEd0yIhQX+wVvFvMFgbCbMgd8F3pInADqFP1gliojzMq+UaPzmAElwhGro1ZdRq9N+iN4KgWDRoz0XlQ02fYm4gbCOZhNwZRXLOpclLWNSQQ/hVgYI206ZPQY8b3s/QqKLhHgqTF81Q2TC02FEBq1ijwkwqAUMipbhoSwvnyiDa+X82L2tOy7idh12jp3bhMHFSuRaqdxVmyfQGBi9P/jegeb2MLTxMDuBW5/rOvdkNtIYEe+hvQXQJ2DJ9AFd8A+BEgW1FFwAnsuDc0LoMoL7AVO8JI2kKYnCyBe4PIDxxHYC/veQRYCGhDyAva9PGr92NdALwYW4XtAjEQxUBft3VtgKE4UBPJNwCsgIbHxECzLwAQs7IEdMMGbnMZWDIyCCbBxJGNQf/SgIFA5uyBIHYPuuyfm4F4bqEz1e5EDLGBBspwXQXrAEUWyF5S2gfoRHxeQPsbG+M5IaRoRqwWJB+xErOtFeIFdCenMOfBEFclg3hNwWqGiF2rfPWQg1gucgSiDxm3k+ACYjmYxHCZi2SnRYGIfEetwoV5QQ5moagwiz0ZIgfWael6we0egqY3wgiJin8/V0CCyt32Ae+8vDKjphRcHiPNCGcj1vUGU71hZaSh4eToVs8JE2e0MRHkBNLz6I4dhqAKQF05Az4wcul4ArWC7zjCkvVDxf/ActUCmF/xxrzIZIl5gxTVbOHS8cH6IRwLQC/5DOydABrcThrwXBtFJC+R64RPDkPfChaHvhQVD3gvfGIa8F/4MfS84DH0vTBj6XigY8l74yzDkvfB76Hvh19D3QsPQ94LA0PdCwJD3wlaFIeBIADOa1ooI9KtsAAAAAElFTkSuQmCC" alt="CBD" height="28">
+      <!-- <span class="bt">CBD <span>Developers</span></span> -->
     </a>
     <span class="crumb">developer.cbd.int</span>
     <nav class="topnav">
       <a href="#" class="on">Docs</a>
       <a href="#">API reference</a>
-      <a href="#">Status</a>
-      <a href="#">Support</a>
+      <a href="#status">Status</a>
+      <a href="#support">Support</a>
       <div class="searchbox">
         <svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"></circle><path d="m20 20-3.2-3.2"></path></svg>
         Search docs… <kbd>/</kbd>
@@ -304,15 +321,15 @@ section.band{padding:54px 0;}
 </section>
 
 <!-- support -->
-<section class="band">
+<section class="band" id="support">
   <div class="wrap">
     <div class="sec-label">Support &amp; contact</div>
     <div class="sup-grid">
-      <a class="sup" href="/cdn-cgi/l/email-protection#e695838594839287948f8792a6858482c88f8892">
+      <a class="sup" href="mailto:secretariat@cbd.int">
         <span class="sicon"><svg viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="14" rx="2"></rect><path d="m3 7 9 6 9-6"></path></svg></span>
         <span class="sname">Write to the Secretariat</span>
         <span class="sdesc">Questions about API access, data coverage or national records — the team replies within a few business days.</span>
-        <span class="slink"><span class="__cf_email__" data-cfemail="94e7f1f7e6f1e0f5e6fdf5e0d4f7f6f0bafdfae0">[email&#160;protected]</span></span>
+        <span class="slink">secretariat@cbd.int</span>
       </a>
       <a class="sup" href="https://github.com/scbd">
         <span class="sicon"><svg viewBox="0 0 24 24"><path d="M12 3a9 9 0 0 0-2.85 17.54c.45.08.62-.2.62-.43v-1.7c-2.51.55-3.04-1.07-3.04-1.07-.41-1.04-1-1.32-1-1.32-.82-.56.06-.55.06-.55.9.06 1.38.93 1.38.93.8 1.38 2.11.98 2.62.75.08-.58.31-.98.57-1.2-2-.23-4.1-1-4.1-4.45 0-.98.35-1.79.93-2.42-.1-.23-.4-1.15.08-2.4 0 0 .76-.24 2.48.92a8.6 8.6 0 0 1 4.51 0c1.72-1.16 2.47-.92 2.47-.92.49 1.25.18 2.17.09 2.4.58.63.93 1.44.93 2.42 0 3.47-2.1 4.22-4.11 4.44.32.28.61.83.61 1.67v2.47c0 .24.16.52.62.43A9 9 0 0 0 12 3Z"></path></svg></span>
@@ -320,13 +337,26 @@ section.band{padding:54px 0;}
         <span class="sdesc">Open-source tooling and issue trackers for the Clearing-House platforms.</span>
         <span class="slink">github.com/scbd</span>
       </a>
-      <a class="sup" href="#">
+      <a class="sup" href="mailto:MEA-CBD-it@un.org">
         <span class="sicon"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"></circle><path d="M9.2 9.2a2.8 2.8 0 0 1 5.5.7c0 1.8-2.7 2.2-2.7 3.6"></path><circle cx="12" cy="17.2" r=".4"></circle></svg></span>
         <span class="sname">Service desk</span>
         <span class="sdesc">Account problems, publishing workflows and focal-point support for Parties.</span>
-        <span class="slink">Open a request →</span>
+        <span class="slink">MEA-CBD-it@un.org</span>
       </a>
     </div>
+  </div>
+</section>
+
+<!-- status -->
+<section class="band" id="status">
+  <div class="wrap">
+    <div class="sec-label">API status</div>
+    <div class="status-overall" id="status-overall">
+      <span class="dot" id="status-overall-dot"></span>
+      <span id="status-overall-text">Checking services…</span>
+    </div>
+    <div class="svc-list" id="svc-list"></div>
+    <p class="status-note">Checks run in your browser using <code>fetch(..., {mode:"no-cors"})</code> with a 5s timeout, so they only detect whether a connection could be established — not HTTP status codes.</p>
   </div>
 </section>
 
@@ -335,10 +365,73 @@ section.band{padding:54px 0;}
   <div class="wrap frow">
     <div class="fnote">© Secretariat of the Convention on Biological Diversity<br>413 Saint-Jacques Street, Montreal, Quebec, Canada</div>
     <div class="flinks">
-      <a href="https://www.cbd.int">cbd.int</a><a href="#">Terms of use</a><a href="#">Privacy</a><a href="#">API status</a>
+      <a href="https://www.cbd.int">cbd.int</a><a href="https://www.cbd.int/terms">Terms of use</a><a href="https://www.cbd.int/privacy">Privacy</a><a href="#status">API status</a>
     </div>
   </div>
 </footer>
 
-<script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script></body>
+<script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script>
+<script>
+const STATUS_SERVICES = [
+  { name: "Clearing-House API", url: "https://api.cbd.int/" },
+  { name: "ABS Clearing-House", url: "https://absch.cbd.int/" },
+  { name: "Biosafety Clearing-House", url: "https://bch.cbd.int/" },
+  { name: "Clearing-House Mechanism", url: "https://chm.cbd.int/" },
+  { name: "Online Reporting Tool", url: "https://ort.cbd.int/" },
+  { name: "Accounts", url: "https://accounts.cbd.int/" },
+];
+
+const STATUS_TIMEOUT_MS = 5000;
+
+function checkService(url) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), STATUS_TIMEOUT_MS);
+  return fetch(url, { mode: "no-cors", cache: "no-store", signal: controller.signal })
+    .then(() => true)
+    .catch(() => false)
+    .finally(() => clearTimeout(timer));
+}
+
+function renderServiceRow(svc) {
+  const row = document.createElement("div");
+  row.className = "svc";
+  row.innerHTML = `
+    <span class="dot" data-dot></span>
+    <span class="svc-name">${svc.name}</span>
+    <span class="svc-url">${svc.url}</span>
+    <span class="svc-badge" data-badge>Checking…</span>
+  `;
+  return row;
+}
+
+async function runStatusChecks() {
+  const list = document.getElementById("svc-list");
+  if (!list) return;
+
+  const rows = STATUS_SERVICES.map((svc) => {
+    const row = renderServiceRow(svc);
+    list.appendChild(row);
+    return row;
+  });
+
+  const results = await Promise.all(STATUS_SERVICES.map((svc) => checkService(svc.url)));
+
+  results.forEach((up, i) => {
+    const row = rows[i];
+    row.querySelector("[data-dot]").classList.add(up ? "up" : "down");
+    const badge = row.querySelector("[data-badge]");
+    badge.classList.add(up ? "up" : "down");
+    badge.textContent = up ? "Reachable" : "Unreachable";
+  });
+
+  const allUp = results.every(Boolean);
+  document.getElementById("status-overall-dot").classList.add(allUp ? "up" : "down");
+  document.getElementById("status-overall-text").textContent = allUp
+    ? "All services reachable"
+    : "Some services are unreachable";
+}
+
+runStatusChecks();
+</script>
+</body>
 </html>

--- a/landing/index.html
+++ b/landing/index.html
@@ -1,0 +1,344 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>CBD Developers — Build with data from the Convention on Biological Diversity</title>
+<meta name="description" content="Documentation and reference material for building on the Convention's data — starting with the Clearing-House API across CHM, ABSCH, BCH and ORT.">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;700&display=swap" rel="stylesheet">
+<style>
+:root{
+  --green-900:#08361f; --green-800:#0c4a2a; --green-700:#0f5c34;
+  --green-600:#157a43; --green-300:#7cc294; --green-100:#e7f2ea; --green-50:#f1f8f3;
+  --ink:#15201b; --body:#33433b; --muted:#6a786f;
+  --line:#e3e7e4; --line-soft:#eef1ef; --page:#fbfcfb;
+  --accent:#157a43; --accent-ink:#0f5c34;
+  --mono:"JetBrains Mono",ui-monospace,SFMono-Regular,Menlo,monospace;
+  --sans:"Public Sans",system-ui,-apple-system,"Segoe UI",sans-serif;
+}
+*{box-sizing:border-box;}
+html,body{margin:0;padding:0;}
+body{font-family:var(--sans);color:var(--body);background:var(--page);
+  -webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;
+  display:flex;flex-direction:column;min-height:100vh;}
+a{color:inherit;text-decoration:none;}
+.wrap{max-width:1180px;margin:0 auto;padding:0 36px;width:100%;}
+
+/* buttons + labels */
+.btn{display:inline-flex;align-items:center;gap:9px;font-weight:700;font-size:15px;
+  padding:13px 22px;border-radius:10px;white-space:nowrap;}
+.btn svg{width:16px;height:16px;}
+.btn.primary{background:var(--green-700);color:#fff;}
+.btn.primary:hover{background:var(--green-800);}
+.btn.ghost{border:1.5px solid var(--line);color:var(--green-800);background:#fff;}
+.btn.ghost:hover{border-color:var(--green-300);}
+.sec-label{display:flex;align-items:center;gap:12px;font-size:12px;font-weight:800;
+  letter-spacing:.1em;text-transform:uppercase;color:var(--muted);margin:0 0 18px;white-space:nowrap;}
+.sec-label::after{content:"";flex:1;height:1px;background:var(--line);}
+h2.sec-title{margin:0 0 8px;font-size:27px;font-weight:800;letter-spacing:-.4px;color:var(--ink);}
+.sec-sub{margin:0 0 28px;font-size:15.5px;color:var(--muted);max-width:62ch;line-height:1.55;}
+
+/* header */
+.topbar{background:#fff;border-bottom:1px solid var(--line);position:sticky;top:0;z-index:50;}
+.top-inner{display:flex;align-items:center;gap:14px;height:64px;}
+.blogo{display:flex;align-items:center;gap:11px;}
+.blogo .bt{font-size:16px;font-weight:800;color:var(--ink);letter-spacing:-.2px;}
+.blogo .bt span{color:var(--green-700);}
+.crumb{font-family:var(--mono);font-size:13px;color:var(--muted);margin-left:4px;}
+.topnav{margin-left:auto;display:flex;align-items:center;gap:24px;font-size:14px;font-weight:600;color:var(--body);}
+.topnav a{white-space:nowrap;}
+.topnav a:hover,.topnav a.on{color:var(--green-700);}
+.searchbox{display:flex;align-items:center;gap:9px;border:1px solid var(--line);
+  border-radius:9px;padding:8px 13px;font-size:13px;color:var(--muted);background:var(--page);
+  min-width:200px;white-space:nowrap;}
+.searchbox svg{width:14px;height:14px;stroke:currentColor;fill:none;stroke-width:2;}
+.searchbox kbd{margin-left:auto;font-family:var(--mono);font-size:10.5px;border:1px solid var(--line);
+  border-radius:4px;padding:1px 5px;background:#fff;color:var(--muted);}
+
+/* hero */
+.hero{border-bottom:1px solid var(--line);background:linear-gradient(180deg,#fff,#fbfcfb);position:relative;overflow:hidden;}
+.hero-grid-bg{position:absolute;inset:0;
+  background-image:linear-gradient(var(--line-soft) 1px,transparent 1px),
+    linear-gradient(90deg,var(--line-soft) 1px,transparent 1px);
+  background-size:44px 44px;
+  -webkit-mask-image:radial-gradient(75% 90% at 30% 20%,#000 30%,transparent 75%);
+  mask-image:radial-gradient(75% 90% at 30% 20%,#000 30%,transparent 75%);}
+.hero-inner{position:relative;padding-top:62px;padding-bottom:58px;display:grid;grid-template-columns:1.15fr 1fr;gap:54px;align-items:center;}
+.eyebrow{font-family:var(--mono);font-size:12.5px;letter-spacing:.08em;color:var(--green-600);
+  text-transform:uppercase;font-weight:700;}
+.hero h1{margin:16px 0 14px;font-size:44px;font-weight:800;letter-spacing:-1.2px;line-height:1.1;color:var(--ink);text-wrap:balance;}
+.hero p.lede{margin:0 0 28px;font-size:16.5px;line-height:1.65;color:var(--body);max-width:52ch;}
+.ctas{display:flex;gap:12px;margin-bottom:26px;}
+.endpoint{display:inline-flex;align-items:center;gap:11px;font-family:var(--mono);font-size:13.5px;
+  background:#fff;border:1px solid var(--line);border-radius:10px;padding:11px 16px;color:var(--green-800);}
+.endpoint .get{font-size:11px;font-weight:800;color:#fff;background:var(--green-600);
+  border-radius:5px;padding:3px 8px;letter-spacing:.05em;}
+
+/* code block */
+.code{background:#0d1f15;border-radius:13px;overflow:hidden;border:1px solid #16331f;}
+.code .chead{display:flex;align-items:center;justify-content:space-between;
+  padding:11px 18px;border-bottom:1px solid rgba(255,255,255,.08);}
+.code .cdots{display:flex;gap:6px;}
+.code .cdots i{width:9px;height:9px;border-radius:50%;background:rgba(255,255,255,.18);}
+.code .clang{font-family:var(--mono);font-size:11.5px;color:#7cc294;letter-spacing:.06em;}
+.code pre{margin:0;padding:20px 22px;font-family:var(--mono);font-size:13.5px;
+  line-height:1.75;color:#d6e8dc;overflow-x:auto;}
+.c-cm{color:#5f8a6e;} .c-str{color:#a7d8b8;} .c-flag{color:#7cc294;} .c-kw{color:#e8d49a;}
+
+/* sections */
+section.band{padding:54px 0;}
+.nets-head{display:flex;align-items:flex-end;justify-content:space-between;gap:24px;margin-bottom:26px;}
+.net-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:16px;}
+.net{display:flex;flex-direction:column;gap:10px;padding:20px;border-radius:11px;
+  background:#fff;border:1px solid var(--line);transition:border-color .15s,box-shadow .15s;}
+.net:hover{border-color:var(--green-300);box-shadow:0 10px 24px -16px rgba(8,54,31,.4);}
+.net .ab{font-family:var(--mono);font-size:13px;font-weight:700;letter-spacing:.04em;
+  color:var(--accent-ink);background:var(--green-50);border:1px solid var(--green-100);
+  padding:4px 9px;border-radius:6px;align-self:flex-start;}
+.net .nname{font-size:15.5px;font-weight:700;color:var(--ink);line-height:1.3;}
+.net .ndesc{font-size:13px;color:var(--muted);line-height:1.5;flex:1;}
+.net .ngo{display:inline-flex;align-items:center;gap:6px;font-size:13px;font-weight:700;color:var(--accent-ink);}
+.net .ngo svg{width:13px;height:13px;}
+.soonline{margin-top:22px;font-family:var(--mono);font-size:12.5px;color:var(--muted);
+  display:flex;align-items:center;gap:10px;}
+.soonline::before{content:"";width:8px;height:8px;border-radius:50%;background:#d8b94a;}
+
+/* quickstart */
+.qs{background:#fff;border-top:1px solid var(--line);border-bottom:1px solid var(--line);}
+.qs-grid{display:grid;grid-template-columns:1fr 1.1fr;gap:48px;align-items:start;}
+.qs-code{padding-top:52px;}
+.steps{display:flex;flex-direction:column;counter-reset:step;}
+.step{display:flex;gap:18px;padding:20px 0;border-bottom:1px solid var(--line-soft);}
+.step:last-child{border-bottom:none;}
+.step .snum{counter-increment:step;flex-shrink:0;width:34px;height:34px;border-radius:10px;
+  background:var(--green-50);border:1px solid var(--green-100);display:flex;align-items:center;
+  justify-content:center;font-family:var(--mono);font-size:14px;font-weight:700;color:var(--green-700);}
+.step .snum::before{content:counter(step);}
+.step .st{font-size:15.5px;font-weight:700;color:var(--ink);margin-bottom:4px;}
+.step .sd{font-size:14px;color:var(--muted);line-height:1.55;}
+.step .sd code{font-family:var(--mono);font-size:12.5px;background:var(--green-50);
+  border:1px solid var(--green-100);border-radius:5px;padding:1px 6px;color:var(--green-800);}
+
+/* support */
+.sup-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:16px;}
+.sup{display:flex;flex-direction:column;gap:9px;padding:22px;border-radius:13px;
+  background:#fff;border:1px solid var(--line);transition:border-color .15s,box-shadow .15s;}
+.sup:hover{border-color:var(--green-300);box-shadow:0 10px 24px -16px rgba(8,54,31,.4);}
+.sup .sicon{width:38px;height:38px;border-radius:10px;background:var(--green-50);
+  display:flex;align-items:center;justify-content:center;color:var(--green-700);margin-bottom:4px;}
+.sup .sicon svg{width:19px;height:19px;fill:none;stroke:currentColor;stroke-width:1.9;
+  stroke-linecap:round;stroke-linejoin:round;}
+.sup .sname{font-size:15.5px;font-weight:700;color:var(--ink);}
+.sup .sdesc{font-size:13.5px;color:var(--muted);line-height:1.55;flex:1;}
+.sup .slink{font-size:13.5px;font-weight:700;color:var(--accent-ink);font-family:var(--mono);}
+
+/* footer */
+.foot{border-top:1px solid var(--line);padding:26px 0 30px;margin-top:auto;}
+.foot .frow{display:flex;align-items:center;justify-content:space-between;gap:20px;}
+.foot .fnote{font-size:12.5px;color:var(--muted);line-height:1.5;}
+.foot .flinks{display:flex;gap:22px;font-size:13px;font-weight:600;color:var(--green-800);}
+.foot .flinks a{white-space:nowrap;}
+.foot .flinks a:hover{color:var(--green-600);}
+
+/* responsive */
+@media (max-width:900px){
+  .hero-inner,.qs-grid{grid-template-columns:1fr;}
+  .net-grid,.sup-grid{grid-template-columns:1fr 1fr;}
+  .crumb,.searchbox{display:none;}
+  .qs-code{padding-top:0;}
+  .hero h1{font-size:36px;}
+}
+@media (max-width:560px){
+  .wrap{padding:0 20px;}
+  .net-grid,.sup-grid{grid-template-columns:1fr;}
+  .topnav{gap:16px;}
+  .foot .frow{flex-direction:column;align-items:flex-start;}
+}
+</style>
+</head>
+<body>
+
+<!-- header -->
+<div class="topbar">
+  <div class="wrap top-inner">
+    <a class="blogo" href="/">
+      <svg width="30" height="33" viewBox="0 0 60 66" fill="none" aria-hidden="true">
+        <path d="M30 4C18 14 14 26 18 40c2 7 7 13 12 18 5-5 10-11 12-18 4-14 0-26-12-36Z" fill="#0f5c34"></path>
+        <path d="M30 8c-7 8-9 18-6 28 1.5 5 4 9 6 12 2-3 4.5-7 6-12 3-10 1-20-6-28Z" fill="#7cc294"></path>
+        <path d="M30 12v50" stroke="#fff" stroke-width="1.6"></path>
+      </svg>
+      <span class="bt">CBD <span>Developers</span></span>
+    </a>
+    <span class="crumb">developer.cbd.int</span>
+    <nav class="topnav">
+      <a href="#" class="on">Docs</a>
+      <a href="#">API reference</a>
+      <a href="#">Status</a>
+      <a href="#">Support</a>
+      <div class="searchbox">
+        <svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"></circle><path d="m20 20-3.2-3.2"></path></svg>
+        Search docs… <kbd>/</kbd>
+      </div>
+    </nav>
+  </div>
+</div>
+
+<!-- hero -->
+<section class="hero">
+  <div class="hero-grid-bg"></div>
+  <div class="wrap hero-inner">
+    <div>
+      <span class="eyebrow">Open biodiversity data</span>
+      <h1>The developer hub for CBD APIs</h1>
+      <p class="lede">Documentation and reference material for building on the Convention's data — starting with the Clearing-House API across CHM, ABSCH, BCH and ORT.</p>
+      <div class="ctas">
+        <a class="btn primary" href="/clearing-house">Clearing-House docs
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M5 12h14m-6-6 6 6-6 6"></path></svg>
+        </a>
+        <a class="btn ghost" href="#quickstart">Quickstart</a>
+      </div>
+      <span class="endpoint"><span class="get">GET</span> api.cbd.int/api/v2013/index</span>
+    </div>
+    <div class="code">
+      <div class="chead">
+        <div class="cdots"><i></i><i></i><i></i></div>
+        <span class="clang">shell</span>
+      </div>
+<pre><span class="c-cm"># Search published Clearing-House records</span>
+<span class="c-kw">curl</span> <span class="c-flag">-G</span> <span class="c-str">"https://api.cbd.int/api/v2013/index"</span> <span class="c-flag">\</span>
+  <span class="c-flag">--data-urlencode</span> <span class="c-str">"q=schema_s:resource"</span> <span class="c-flag">\</span>
+  <span class="c-flag">-H</span> <span class="c-str">"Accept: application/json"</span>
+
+<span class="c-cm"># → 200 OK · JSON list of matching records</span></pre>
+    </div>
+  </div>
+</section>
+
+<!-- networks -->
+<section class="band">
+  <div class="wrap">
+    <div class="nets-head">
+      <div>
+        <h2 class="sec-title">One API, four platforms</h2>
+        <p class="sec-sub" style="margin:0;">The Clearing-House API serves records from each of the Convention's information-sharing platforms through a common schema model.</p>
+      </div>
+    </div>
+    <div class="net-grid">
+      <a class="net" href="/clearing-house">
+        <span class="ab">CHM</span>
+        <span class="nname">Clearing-House Mechanism</span>
+        <span class="ndesc">Information-sharing records under the Convention — national targets, NBSAPs, contacts and resources.</span>
+        <span class="ngo">View reference <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M5 12h14m-6-6 6 6-6 6"></path></svg></span>
+      </a>
+      <a class="net" href="/clearing-house">
+        <span class="ab">ABSCH</span>
+        <span class="nname">Access &amp; Benefit-Sharing Clearing-House</span>
+        <span class="ndesc">Permits, checkpoints and national records under the Nagoya Protocol.</span>
+        <span class="ngo">View reference <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M5 12h14m-6-6 6 6-6 6"></path></svg></span>
+      </a>
+      <a class="net" href="/clearing-house">
+        <span class="ab">BCH</span>
+        <span class="nname">Biosafety Clearing-House</span>
+        <span class="ndesc">Decisions, risk assessments and LMO registries under the Cartagena Protocol.</span>
+        <span class="ngo">View reference <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M5 12h14m-6-6 6 6-6 6"></path></svg></span>
+      </a>
+      <a class="net" href="/clearing-house">
+        <span class="ab">ORT</span>
+        <span class="nname">Online Reporting Tool</span>
+        <span class="ndesc">Structured national report data submitted by Parties through the reporting tool.</span>
+        <span class="ngo">View reference <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M5 12h14m-6-6 6 6-6 6"></path></svg></span>
+      </a>
+    </div>
+    <div class="soonline">More CBD APIs — meetings, notifications, documents — coming soon</div>
+  </div>
+</section>
+
+<!-- quickstart -->
+<section class="band qs" id="quickstart">
+  <div class="wrap qs-grid">
+    <div>
+      <div class="sec-label">Getting started</div>
+      <h2 class="sec-title">Three steps to your first record</h2>
+      <p class="sec-sub">Plain HTTPS and JSON — usable from any language, no SDK needed.</p>
+      <div class="steps">
+        <div class="step">
+          <div class="snum"></div>
+          <div>
+            <div class="st">Browse the record schemas</div>
+            <div class="sd">Every record in the Clearing-House follows a published schema. Start with the schema reference to see what's available across CHM, ABSCH, BCH and ORT.</div>
+          </div>
+        </div>
+        <div class="step">
+          <div class="snum"></div>
+          <div>
+            <div class="st">Make your first request</div>
+            <div class="sd">Published records are readable without an API key. Query the search index with a simple <code>GET</code> request and filter by schema, government or realm.</div>
+          </div>
+        </div>
+        <div class="step">
+          <div class="snum"></div>
+          <div>
+            <div class="st">Authenticate for more</div>
+            <div class="sd">Draft records and national workflows require a CBD account. The docs cover tokens, roles and the publishing lifecycle.</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="qs-code">
+      <div class="code">
+        <div class="chead">
+          <div class="cdots"><i></i><i></i><i></i></div>
+          <span class="clang">shell</span>
+        </div>
+<pre><span class="c-cm"># Search published Clearing-House records</span>
+<span class="c-kw">curl</span> <span class="c-flag">-G</span> <span class="c-str">"https://api.cbd.int/api/v2013/index"</span> <span class="c-flag">\</span>
+  <span class="c-flag">--data-urlencode</span> <span class="c-str">"q=schema_s:resource"</span> <span class="c-flag">\</span>
+  <span class="c-flag">-H</span> <span class="c-str">"Accept: application/json"</span>
+
+<span class="c-cm"># → 200 OK · JSON list of matching records</span></pre>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- support -->
+<section class="band">
+  <div class="wrap">
+    <div class="sec-label">Support &amp; contact</div>
+    <div class="sup-grid">
+      <a class="sup" href="/cdn-cgi/l/email-protection#e695838594839287948f8792a6858482c88f8892">
+        <span class="sicon"><svg viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="14" rx="2"></rect><path d="m3 7 9 6 9-6"></path></svg></span>
+        <span class="sname">Write to the Secretariat</span>
+        <span class="sdesc">Questions about API access, data coverage or national records — the team replies within a few business days.</span>
+        <span class="slink"><span class="__cf_email__" data-cfemail="94e7f1f7e6f1e0f5e6fdf5e0d4f7f6f0bafdfae0">[email&#160;protected]</span></span>
+      </a>
+      <a class="sup" href="https://github.com/scbd">
+        <span class="sicon"><svg viewBox="0 0 24 24"><path d="M12 3a9 9 0 0 0-2.85 17.54c.45.08.62-.2.62-.43v-1.7c-2.51.55-3.04-1.07-3.04-1.07-.41-1.04-1-1.32-1-1.32-.82-.56.06-.55.06-.55.9.06 1.38.93 1.38.93.8 1.38 2.11.98 2.62.75.08-.58.31-.98.57-1.2-2-.23-4.1-1-4.1-4.45 0-.98.35-1.79.93-2.42-.1-.23-.4-1.15.08-2.4 0 0 .76-.24 2.48.92a8.6 8.6 0 0 1 4.51 0c1.72-1.16 2.47-.92 2.47-.92.49 1.25.18 2.17.09 2.4.58.63.93 1.44.93 2.42 0 3.47-2.1 4.22-4.11 4.44.32.28.61.83.61 1.67v2.47c0 .24.16.52.62.43A9 9 0 0 0 12 3Z"></path></svg></span>
+        <span class="sname">SCBD on GitHub</span>
+        <span class="sdesc">Open-source tooling and issue trackers for the Clearing-House platforms.</span>
+        <span class="slink">github.com/scbd</span>
+      </a>
+      <a class="sup" href="#">
+        <span class="sicon"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"></circle><path d="M9.2 9.2a2.8 2.8 0 0 1 5.5.7c0 1.8-2.7 2.2-2.7 3.6"></path><circle cx="12" cy="17.2" r=".4"></circle></svg></span>
+        <span class="sname">Service desk</span>
+        <span class="sdesc">Account problems, publishing workflows and focal-point support for Parties.</span>
+        <span class="slink">Open a request →</span>
+      </a>
+    </div>
+  </div>
+</section>
+
+<!-- footer -->
+<footer class="foot">
+  <div class="wrap frow">
+    <div class="fnote">© Secretariat of the Convention on Biological Diversity<br>413 Saint-Jacques Street, Montreal, Quebec, Canada</div>
+    <div class="flinks">
+      <a href="https://www.cbd.int">cbd.int</a><a href="#">Terms of use</a><a href="#">Privacy</a><a href="#">API status</a>
+    </div>
+  </div>
+</footer>
+
+<script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script></body>
+</html>

--- a/landing/index.html
+++ b/landing/index.html
@@ -243,25 +243,25 @@ section.band{padding:54px 0;}
       </div>
     </div>
     <div class="net-grid">
-      <a class="net" href="/clearing-house">
+      <a class="net" href="/clearing-house/chm">
         <span class="ab">CHM</span>
         <span class="nname">Clearing-House Mechanism</span>
         <span class="ndesc">Information-sharing records under the Convention — national targets, NBSAPs, contacts and resources.</span>
         <span class="ngo">View reference <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M5 12h14m-6-6 6 6-6 6"></path></svg></span>
       </a>
-      <a class="net" href="/clearing-house">
+      <a class="net" href="/clearing-house/abs">
         <span class="ab">ABSCH</span>
         <span class="nname">Access &amp; Benefit-Sharing Clearing-House</span>
         <span class="ndesc">Permits, checkpoints and national records under the Nagoya Protocol.</span>
         <span class="ngo">View reference <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M5 12h14m-6-6 6 6-6 6"></path></svg></span>
       </a>
-      <a class="net" href="/clearing-house">
+      <a class="net" href="/clearing-house/bch">
         <span class="ab">BCH</span>
         <span class="nname">Biosafety Clearing-House</span>
         <span class="ndesc">Decisions, risk assessments and LMO registries under the Cartagena Protocol.</span>
         <span class="ngo">View reference <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M5 12h14m-6-6 6 6-6 6"></path></svg></span>
       </a>
-      <a class="net" href="/clearing-house">
+      <a class="net" href="/clearing-house/ort">
         <span class="ab">ORT</span>
         <span class="nname">Online Reporting Tool</span>
         <span class="ndesc">Structured national report data submitted by Parties through the reporting tool.</span>

--- a/landing/package-lock.json
+++ b/landing/package-lock.json
@@ -1,0 +1,824 @@
+{
+  "name": "landing",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "express": "^4.21.2"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/landing/package.json
+++ b/landing/package.json
@@ -1,0 +1,6 @@
+{
+  "type": "module",
+  "dependencies": {
+    "express": "^4.21.2"
+  }
+}

--- a/landing/package.json
+++ b/landing/package.json
@@ -1,5 +1,8 @@
 {
   "type": "module",
+  "scripts": {
+    "start": "node server.js"
+  },
   "dependencies": {
     "express": "^4.21.2"
   }

--- a/landing/server.js
+++ b/landing/server.js
@@ -1,0 +1,10 @@
+import express from "express";
+import { readFileSync } from "fs";
+
+const app = express();
+const html = readFileSync(new URL("index.html", import.meta.url));
+const port = process.env.PORT || 3000;
+
+app.get("*", (_, res) => res.type("html").send(html));
+
+app.listen(port, () => console.log(`listening on http://localhost:${port}`));

--- a/swagger/view/SwaggerUI.vue
+++ b/swagger/view/SwaggerUI.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="mt-4" v-show="!isLoading && !isError">
     <div class="alert alert-info" role="alert">
-      This playground connects to the sandbox environment (<code>cbddev.xyz</code>) for testing purposes.
-      In production, replace <code>cbddev.xyz</code> with <code>cbd.int</code> in request URLs.
+      This playground connects to the production environment (<code>cbd.int</code>).
+      Requests made here affect real, live data.
     </div>
     <div v-for="(spec, index) in swaggerSpecs" :key="index">
       <div v-if="spec.protected && !token">

--- a/swagger/view/SwaggerUI.vue
+++ b/swagger/view/SwaggerUI.vue
@@ -1,5 +1,9 @@
 <template>
   <div class="mt-4" v-show="!isLoading && !isError">
+    <div class="alert alert-info" role="alert">
+      This playground connects to the sandbox environment (<code>cbddev.xyz</code>) for testing purposes.
+      In production, replace <code>cbddev.xyz</code> with <code>cbd.int</code> in request URLs.
+    </div>
     <div v-for="(spec, index) in swaggerSpecs" :key="index">
       <div v-if="spec.protected && !token">
         <div class="container">


### PR DESCRIPTION
This pull request introduces a dedicated developer landing page and enhances the documentation site's Docker image for improved deployment flexibility.

A new static landing page is added, providing an entry point for developers with information on the CBD APIs, a service status checker, and links to documentation. Its Docker image build and deployment are integrated into the CI/CD pipeline.

The existing documentation Docker image is refactored to be base-path agnostic. Instead of baking the `BASE_PATH` at build time, a new `docker-entrypoint.sh` script dynamically rewrites paths at container startup. This allows the same image to be deployed under various sub-paths without rebuilding. The CI workflow is updated to support this new build approach, including base path verification during testing.

Additionally, environment configurations are standardized:
- The documentation's API playground now hardcodes URLs to the production `cbd.int` domain.
- The Swagger UI includes a prominent alert, warning users that it connects to the live production environment and affects real data.