### PR TITLE
feat: Add Google Analytics to documentation and landing page

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -7,6 +7,8 @@ export default defineConfig({
   base: process.env.BASE_PATH || "/",
   appearance: true,
   head: [
+    ["script", { async: "", src: "https://www.googletagmanager.com/gtag/js?id=G-6EJJLWGHYC" }],
+    ["script", {}, "window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-6EJJLWGHYC');"],
     ["link", { rel: "preconnect", href: "https://fonts.googleapis.com" }],
     ["link", { rel: "preconnect", href: "https://fonts.gstatic.com", crossorigin: "" }],
     [

--- a/landing/index.html
+++ b/landing/index.html
@@ -3,6 +3,13 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-6EJJLWGHYC"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-6EJJLWGHYC');
+</script>
 <title>CBD Developers — Build with data from the Convention on Biological Diversity</title>
 <meta name="description" content="Documentation and reference material for building on the Convention's data — starting with the Clearing-House API across CHM, ABSCH, BCH and ORT.">
 <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
Integrates Google Analytics (ID G-6EJJLWGHYC) to enable tracking of user engagement and traffic across both the VitePress documentation site and the main landing page.

Additionally, this commit:
- Enables the appearance (dark/light mode) toggle for the documentation site.
- Imports "Public Sans" and "JetBrains Mono" Google Fonts for consistent typography within the documentation.